### PR TITLE
Swap class & column name for multiclass mapping

### DIFF
--- a/nannyml_cloud_sdk/schema.py
+++ b/nannyml_cloud_sdk/schema.py
@@ -223,13 +223,13 @@ class Schema:
         """Set the prediction score column(s) in a schema.
 
         Binary classification and regression problems require a single prediction score column.
-        Multiclass classification problems require a dictionary mapping prediction score columns to class names, e.g.
-        `{'prediction_score_1': 'class_1', 'prediction_score_2': 'class_2'}`.
+        Multiclass classification problems require a dictionary mapping class names to prediction score columns, e.g.
+        `{'class_1': 'prediction_score_1', 'class_2': 'prediction_score_2'}`.
 
         Args:
             schema: The schema to modify.
-            column_name_or_mapping: The name of the prediction score column or a dictionary mapping prediction score
-                column names to class names. Any existing prediction score columns will be changed to feature columns.
+            column_name_or_mapping: The name of the prediction score column or a dictionary mapping class names to
+                prediction score column names. Any existing prediction score columns will be changed to feature columns.
 
         Returns:
             The modified schema.
@@ -243,7 +243,9 @@ class Schema:
                 'Must specify a single prediction score column name for binary classification and regression'
             )
         else:
-            column_name_or_mapping = {normalize(key): value for (key, value) in column_name_or_mapping.items()}
+            column_name_or_mapping = {
+                normalize(column_name): class_name for (class_name, column_name) in column_name_or_mapping.items()
+            }
 
         for column in schema['columns']:
             if column['name'] in column_name_or_mapping:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -139,26 +139,26 @@ def test_schema_set_prediction_score_multiclass_classification_sets_column_type(
             {'name': 'b', 'columnType': 'CONTINUOUS_FEATURE', 'dataType': 'float64', 'className': None},
         ]
     }
-    new_schema = Schema.set_prediction_score(schema, {'a': 'A', 'b': 'B'})
+    new_schema = Schema.set_prediction_score(schema, {'class_a': 'a', 'class_b': 'b'})
 
     assert new_schema is schema
     assert schema['columns'][0]['columnType'] == 'PREDICTION_SCORE'
-    assert schema['columns'][0]['className'] == 'A'
+    assert schema['columns'][0]['className'] == 'class_a'
     assert schema['columns'][1]['columnType'] == 'PREDICTION_SCORE'
-    assert schema['columns'][1]['className'] == 'B'
+    assert schema['columns'][1]['className'] == 'class_b'
 
 
 def test_schema_set_prediction_score_multiclass_classification_unsets_existing_prediction_score() -> None:
     schema: ModelSchema = {
         'problemType': 'MULTICLASS_CLASSIFICATION',
         'columns': [
-            {'name': 'a', 'columnType': 'PREDICTION_SCORE', 'dataType': 'float64', 'className': 'A'},
-            {'name': 'b', 'columnType': 'PREDICTION_SCORE', 'dataType': 'float64', 'className': 'B'},
+            {'name': 'a', 'columnType': 'PREDICTION_SCORE', 'dataType': 'float64', 'className': 'class_a'},
+            {'name': 'b', 'columnType': 'PREDICTION_SCORE', 'dataType': 'float64', 'className': 'class_b'},
             {'name': 'c', 'columnType': 'CONTINUOUS_FEATURE', 'dataType': 'float64', 'className': None},
             {'name': 'd', 'columnType': 'CONTINUOUS_FEATURE', 'dataType': 'float64', 'className': None},
         ]
     }
-    new_schema = Schema.set_prediction_score(schema, {'c': 'C', 'd': 'D'})
+    new_schema = Schema.set_prediction_score(schema, {'class_c': 'c', 'class_d': 'd'})
 
     assert new_schema is schema
     assert schema['columns'][0]['columnType'] == 'CONTINUOUS_FEATURE'
@@ -166,9 +166,9 @@ def test_schema_set_prediction_score_multiclass_classification_unsets_existing_p
     assert schema['columns'][1]['columnType'] == 'CONTINUOUS_FEATURE'
     assert schema['columns'][1]['className'] is None
     assert schema['columns'][2]['columnType'] == 'PREDICTION_SCORE'
-    assert schema['columns'][2]['className'] == 'C'
+    assert schema['columns'][2]['className'] == 'class_c'
     assert schema['columns'][3]['columnType'] == 'PREDICTION_SCORE'
-    assert schema['columns'][3]['className'] == 'D'
+    assert schema['columns'][3]['className'] == 'class_d'
 
 
 def test_schema_set_prediction_score_multiclass_classification_rejects_single_prediction_score() -> None:


### PR DESCRIPTION
The NannyML OSS library uses a `{class: pred_score}` style mapping. The SDK should follow instead of swapping them.