### PR TITLE
Raise `LicenseError` if API reports license issue

### DIFF
--- a/nannyml_cloud_sdk/errors.py
+++ b/nannyml_cloud_sdk/errors.py
@@ -6,5 +6,9 @@ class ApiError(SdkError):
     """Raised when the NannyML Cloud API returns an error"""
 
 
+class LicenseError(SdkError):
+    """Raised when the NannyML Cloud API returns a license error"""
+
+
 class InvalidOperationError(SdkError):
     """Raised when attempting an invalid operation"""


### PR DESCRIPTION
This PR introduces a new error type `LicenseError` that is raised when the NannyML Cloud server reports a license issue.