### PR TITLE
Segmentation support

### DIFF
--- a/nannyml_cloud_sdk/monitoring/schema.py
+++ b/nannyml_cloud_sdk/monitoring/schema.py
@@ -303,6 +303,24 @@ class Schema:
         return schema
 
     @classmethod
+    def set_segment(cls, schema: ModelSchema, column_name: str) -> ModelSchema:
+        """Sets the SEGMENT column flag for a column in a schema.
+
+        Args:
+            schema: The schema to modify.
+            column_name: The name of the column to mark as a segment column. The column will keep its original type.
+
+        Returns:
+            The modified schema.
+        """
+        column_name = normalize(column_name)
+        for column in schema['columns']:
+            if column['name'] == column_name:
+                column['columnFlags'].append('SEGMENT')
+
+        return schema
+
+    @classmethod
     def _guess_feature_type(cls, column: ColumnDetails) -> ColumnType:
         """Guess feature type from column details."""
         return (

--- a/nannyml_cloud_sdk/monitoring/schema.py
+++ b/nannyml_cloud_sdk/monitoring/schema.py
@@ -32,6 +32,7 @@ class Schema:
         identifier_column_name: Optional[str] = ...,
         feature_columns: Dict[str, FeatureType] = ...,
         ignore_column_names: Union[str, Collection[str]] = ...,
+        segment_column_names: Union[str, Collection[str]] = ...,
     ) -> ModelSchema:
         """First"""
         pass
@@ -49,6 +50,8 @@ class Schema:
         identifier_column_name: Optional[str] = ...,
         feature_columns: Dict[str, FeatureType] = ...,
         ignore_column_names: Union[str, Collection[str]] = ...,
+        segment_column_names: Union[str, Collection[str]] = ...,
+
     ) -> ModelSchema:
         """Create a schema from a pandas dataframe.
 
@@ -69,6 +72,7 @@ class Schema:
         identifier_column_name: Optional[str] = None,
         feature_columns: Dict[str, FeatureType] = {},
         ignore_column_names: Union[str, Collection[str]] = (),
+        segment_column_names: Union[str, Collection[str]] = (),
     ) -> ModelSchema:
         """Create a schema from a pandas dataframe.
 
@@ -95,6 +99,8 @@ class Schema:
             feature_columns: A dictionary specifying whether features are `CATEGORICAL` or `CONTINUOUS`. Feature columns
                 that are not specified will retain their original [type][nannyml_cloud_sdk.enums.FeatureType].
             ignore_column_names: The names of columns to ignore.
+            segment_column_names: The names of columns to mark as segment sources. Their values will be used
+                to segment the data. The column will keep its original type.
 
         Returns:
             The inspected schema with any modifications applied.
@@ -126,6 +132,8 @@ class Schema:
         for column_name, feature_type in feature_columns.items():
             schema = cls.set_feature(schema, column_name, feature_type)
         schema = cls.set_ignored(schema, ignore_column_names)
+        for column_name in segment_column_names:
+            schema = cls.set_segment(schema, column_name)
 
         return schema
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -28,6 +28,7 @@ type StandardDeviationThreshold implements Thresholdbase & Threshold {
 }
 
 type KdeDistributionResult implements Result {
+  id: String!
   modelId: Int!
   analysisType: AnalysisType!
   calculatorType: CalculatorType!
@@ -38,6 +39,7 @@ type KdeDistributionResult implements Result {
 }
 
 interface Result {
+  id: String!
   modelId: Int!
   analysisType: AnalysisType!
   calculatorType: CalculatorType!
@@ -57,11 +59,12 @@ enum AnalysisType {
 
 enum CalculatorType {
   CBPE
-  MCBPE
+  PAPE
   DLE
   PERFORMANCE_CALCULATION
   UNIVARIATE_DRIFT
-  MULTIVARIATE_DRIFT
+  RECONSTRUCTION_ERROR
+  DOMAIN_CLASSIFIER
   MISSING_VALUES
   UNSEEN_VALUES
   RCS
@@ -129,6 +132,7 @@ enum DataPeriod {
 }
 
 type TimeSeriesResult implements Result {
+  id: String!
   modelId: Int!
   analysisType: AnalysisType!
   calculatorType: CalculatorType!
@@ -142,7 +146,6 @@ type TimeSeriesResult implements Result {
   stdev: Float
   data(filter: ResultDataFilter = null): [TimeSeriesDataPoint!]!
   lastDataPoint: TimeSeriesDataPoint
-  nrAlerts: Int!
   config: MetricConfig!
 }
 
@@ -170,6 +173,7 @@ type SegmentThreshold {
 }
 
 type ValueCountDistributionResult implements Result {
+  id: String!
   modelId: Int!
   analysisType: AnalysisType!
   calculatorType: CalculatorType!
@@ -328,6 +332,7 @@ type Query {
   verify_auth(authSettings: AuthenticationSettingsInput!, accessToken: String!): Boolean!
   send_test_email(settings: EmailSmtpSettingsInput!, recipient: String!): Void
   send_test_webhook_call(settings: WebhookNotificationSettingsInput!): Void
+  version: VersionInfo!
   monitoring_models(filter: ModelsFilter = null): [Model!]!
   monitoring_model(id: Int!): Model
   get_default_monitoring_runtime_config(input: GetDefaultMonitoringRuntimeConfigInput!): RuntimeConfig!
@@ -346,6 +351,7 @@ type DataSourceInspectData {
 type Column {
   name: String!
   columnType: ColumnType!
+  columnFlags: [ColumnFlag!]!
   dataType: String!
   className: String
 }
@@ -363,6 +369,9 @@ enum ColumnType {
   GROUP_NAME
   SUCCESS_COUNT
   FAIL_COUNT
+}
+
+enum ColumnFlag {
   SEGMENT
 }
 
@@ -453,6 +462,7 @@ input InspectExperimentDataSourceInput {
 input ColumnInput {
   name: String!
   columnType: ColumnType!
+  columnFlags: [ColumnFlag!]!
   dataType: String!
   className: String = null
 }
@@ -585,6 +595,17 @@ input WebhookNotificationHeaderInput {
   value: String!
 }
 
+type VersionInfo {
+  applicationVersion: String!
+  serverVersion: String!
+  products: [ProductVersionInfo!]!
+}
+
+type ProductVersionInfo {
+  product: ProductType!
+  version: String!
+}
+
 type Model {
   id: Int!
   name: String!
@@ -597,7 +618,7 @@ type Model {
   kpm: KeyPerformanceMetric!
   dataSources(filter: DataSourcesFilter = null): [DataSource!]!
   runs: [Run!]!
-  results(filter: ModelResultsFilter = null, includeDisabled: Boolean! = false): [Result!]!
+  results(filter: [ModelResultsFilter!] = null, includeDisabled: Boolean! = false): [Result!]!
   runtimeConfig: RuntimeConfig!
   runnerConfig: JSON!
   schedules: [Schedule!]!
@@ -653,7 +674,7 @@ enum RunEventType {
 type KeyPerformanceMetric {
   metric: PerformanceMetric!
   component: String
-  results: [TimeSeriesResult!]!
+  results(segments: [Int] = null): [TimeSeriesResult!]!
 }
 
 type DataSource {
@@ -739,7 +760,7 @@ type PerformanceTypeConfig implements SupportConfigInterface {
 
 enum PerformanceType {
   CBPE
-  MCBPE
+  PAPE
   DLE
   REALIZED
 }
@@ -779,6 +800,7 @@ type MultivariateDriftMethodConfig implements SimpleMetricConfig & MetricConfig 
 
 enum MultivariateDriftMethod {
   PCA_RECONSTRUCTION_ERROR
+  DOMAIN_CLASSIFIER_AUROC
 }
 
 type DataQualityMetricConfig implements ColumnMetricConfig & MetricConfig {
@@ -1370,6 +1392,7 @@ input EditDataSourceColumnTypesInput {
 input ColumnTypeInput {
   name: String!
   columnType: ColumnType!
+  columnFlags: [ColumnFlag!]!
 }
 
 input EditKeyPerformanceMetricInput {


### PR DESCRIPTION
This PR adds support for segmentation on model creation.

I've added a `set_segment` method to the `Schema` class, allowing to specify a column to mark as a segment source.

```
schema = sdk.monitoring.Schema.from_df(
    'BINARY_CLASSIFICATION',
    reference_data,
    identifier_column_name='id',
    timestamp_column_name='timestamp',
    prediction_column_name='y_pred',
    prediction_score_column_name_or_mapping='y_pred_proba',
    target_column_name='repaid'
)

schema = sdk.monitoring.Schema.set_segment(schema, 'salary_range')
```