### PR TITLE
Fix creating a model with `chunk_size` argument

### DIFF
--- a/nannyml_cloud_sdk/monitoring/configuration.py
+++ b/nannyml_cloud_sdk/monitoring/configuration.py
@@ -262,12 +262,16 @@ class RuntimeConfiguration:
 
     @staticmethod
     def default(
-        problem_type: ProblemType, chunking: Chunking, data_sources: List[dict[str, Any]]
+        problem_type: ProblemType,
+        chunking: Chunking,
+        data_sources: List[dict[str, Any]],
+        nr_of_rows: Optional[int] = None
     ) -> dict[str, Any]:
         rc = execute(_GET_DEFAULT_RUNTIME_CONFIGURATION, {
             'input': {
                 'problemType': problem_type,
                 'chunking': chunking,
+                'nrOfRows': nr_of_rows,
                 'dataSources': data_sources
             }
         })['get_default_monitoring_runtime_config']

--- a/nannyml_cloud_sdk/monitoring/model.py
+++ b/nannyml_cloud_sdk/monitoring/model.py
@@ -222,14 +222,16 @@ class Model:
             })
 
         runtime_config = RuntimeConfiguration.default(
-            schema['problemType'], chunk_period if chunk_period is not None else 'NUMBER_OF_ROWS', data_sources)
+            problem_type=schema['problemType'],
+            chunking=chunk_period if chunk_period is not None else 'NUMBER_OF_ROWS',
+            data_sources=data_sources,
+            nr_of_rows=chunk_size
+        )
 
         return execute(_CREATE_MODEL, {
             'input': {
                 'name': name,
                 'problemType': schema['problemType'],
-                'chunkAggregation': chunk_period if chunk_period is not None else 'NUMBER_OF_ROWS',
-                'numberOfRows': chunk_size,
                 'dataSources': data_sources,
                 'kpm': {
                     'metric': key_performance_metric,


### PR DESCRIPTION
The `create_model` API was changed to accept a `runtimeConfig` argument in https://github.com/NannyML/nannyml-cloud-sdk/pull/13, but the `chunk_size` argument was not correctly included.

This commit fixes that by passing the `chunk_size` to the `RuntimeConfiguration.default` call to generate an appropriate runtime config.